### PR TITLE
BearSSL: fehlende TLS-Server-Einstiegsfunktionen ergaenzen

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/ssl/ssl_server_min.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ssl/ssl_server_min.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * br_ssl_server_zero() + br_ssl_server_reset() aus dem Upstream-BearSSL
+ * (src/ssl/ssl_server.c). Die Tasmota-Lib wurde clientseitig zugeschnitten;
+ * die Server-Handshake-Maschine (ssl_hs_server.c) und die EC-Server-Policy
+ * (ssl_scert_single_ec.c) sind vorhanden, nur diese beiden Einstiegs-
+ * funktionen fehlten. Struktur gespiegelt an br_ssl_client_reset()
+ * (ssl_client.c) dieser Lib. Benoetigt vom SHIP-Server in
+ * xdrv_126_eebus_guard.ino (USE_EEBUS_GUARD, eingehende SHIP-Verbindungen).
+ */
+
+#include "t_inner.h"
+
+/* see bearssl_ssl.h */
+void
+br_ssl_server_zero(br_ssl_server_context *cc)
+{
+	/*
+	 * For really standard C, we should explicitly set to NULL all
+	 * pointers, and 0 all other fields. However, on all our target
+	 * architectures, a direct memset() will set all bytes to 0,
+	 * which means that all 'normal' types will be set to 0, and
+	 * pointers will be NULL.
+	 */
+	memset(cc, 0, sizeof *cc);
+}
+
+/* see bearssl_ssl.h */
+int
+br_ssl_server_reset(br_ssl_server_context *cc)
+{
+	br_ssl_engine_set_buffer(&cc->eng, NULL, 0, 0);
+	cc->eng.version_out = cc->eng.version_min;
+	if (!br_ssl_engine_init_rand(&cc->eng)) {
+		return 0;
+	}
+	cc->eng.reneg = 0;
+	br_ssl_engine_hs_reset(&cc->eng,
+		br_ssl_hs_server_init_main, br_ssl_hs_server_run);
+	return br_ssl_engine_last_error(&cc->eng) == BR_ERR_OK;
+}


### PR DESCRIPTION
Erster von drei Beitraegen, wie in unserem Briefwechsel abgesprochen.

## Was fehlt

`br_ssl_server_zero()` und `br_ssl_server_reset()` sind in `t_bearssl_ssl.h` deklariert, aber nirgends definiert. Die Server-Handshake-Maschine (`ssl_hs_server.c`) und die EC-Zertifikatspolicy (`ssl_scert_single_ec.c`) liegen bereits im Baum -- es fehlten nur diese zwei Einstiegsfunktionen. Ohne sie ist kein TLS-Server moeglich, obwohl fast alles dafuer schon vorhanden ist.

## Was die Datei tut

Genau diese zwei Funktionen, aus dem BearSSL-Upstream (`src/ssl/ssl_server.c`) uebernommen. Der MIT-Lizenzkopf (Thomas Pornin) ist unveraendert enthalten. `reset` ist an `br_ssl_client_reset` dieser Lib gespiegelt: `set_buffer(NULL,0,0)`, also Puffer behalten und nur die I/O zuruecksetzen.

Rein additiv: eine neue Datei, 64 Zeilen, LF. Sie kann nichts brechen, was vorher lief -- vorher existierte davon nichts.

md5 `814edf8e35c62620e405b3bd9881ebcd`

## Wofuer

Gebraucht fuer einen SHIP-Server (EEBUS): manche Geraete bauen die Verbindung von sich aus zum Steuergeraet auf und warten darauf, dass sie angenommen wird. Der Nutzen reicht aber weiter -- damit kann Tasmota ueberhaupt erst TLS-Server sein, ganz unabhaengig von EEBUS.

## Checkliste, ehrlich ausgefuellt

- [x] Gegen den aktuellen Entwicklungszweig (hier `universal`)
- [x] Nur relevante Dateien angefasst -- es ist genau eine, und sie ist neu
- [x] Nur eine Sache pro Pull Request
- [ ] **ESP8266: nicht getestet.** Ich habe kein ESP8266-Geraet. Die Datei ist plattformunabhaengiger BearSSL-Code, aber gemessen habe ich es nicht.
- [x] ESP32: getestet auf ESP32-S3 mit Ethernet (W5500), Tasmota 15.5.0.1, ueber Wochen im Betrieb mit eingehenden TLS-Verbindungen von drei verschiedenen Fabrikaten
- [ ] CLA: dazu sage ich bewusst nichts, weil ich nicht beurteilen kann, ob sie fuer diesen Fork gilt. Wenn ja, sag es und ich hole es nach.

Zur Offenheit: geschrieben und geprueft habe ich das mit Claude. Getestet ist es an echter Hardware, aber du solltest wissen, wo es herkommt.