### PR TITLE
fix(tls_mini): write out SHA1 digest for EC public key fingerprints

### DIFF
--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -843,6 +843,8 @@ extern "C" {
       int32_t curve = htonl(eckey.curve);
       sha1_update_len(&shactx, &curve, 4);   // curve id as int32be
       sha1_update_len(&shactx, eckey.q, eckey.qlen);       // public point
+
+      br_sha1_out(&shactx, xc->pubkey_recv_fingerprint); // copy to fingerprint
     }
   #endif
     else {


### PR DESCRIPTION
## Description:

The EC branch of `pubkeyfingerprint_pubkey_fingerprint()` computes the SHA1 digest of the server's
public key but never writes it out. `br_sha1_out()` occurs exactly once in the whole file -- in the
RSA branch. As a result `xc->pubkey_recv_fingerprint` keeps whatever was in that buffer before, and
the comparison in `pubkeyfingerprint_end_chain()` runs against uninitialised data.

Three paths consume that buffer:

* **MQTT with `tls_use_fingerprint`** -- the check passes or fails on meaningless data. A user who
  enabled it believes the connection is pinned to a specific server; it is not.
* **MQTT fingerprint learning** -- worse, it becomes permanent: the value is copied into
  `Settings->mqtt_fingerprint[...]`, reported as "Fingerprint learned" and persisted via
  `SettingsSaveAll()`. The device then validates against a meaningless value from then on.
* **Telegram** uses `setPubKeyFingerprint(..., false)`, i.e. the strict check.

With Let's Encrypt issuing ECDSA certificates by default, this path is common rather than exotic.

The fix is one line, mirroring what the RSA branch already does.

### Migration note

Devices that already learned a fingerprint against an ECDSA server hold a meaningless value. After
this fix the comparison starts working, so **those connections will fail** -- correctly, but it will
look as though this change broke them. Resetting the stored fingerprint to zero makes the device
learn it again, this time correctly. Worth a line in the release notes.

**Related issue (if applicable):** none. The same defect is present in upstream Tasmota; it has been
reported there through the contact form that the project's security policy points to.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

**About the two testing boxes, to be explicit:** this was found by reading the code, not by
measurement -- no ECDSA broker was available here to demonstrate it at runtime. The ESP8266 box does
not apply either: the EC branch sits inside `#ifndef ESP8266`. The RSA path is untouched, and the EC
path could not have produced a correct fingerprint under any circumstances, since the digest was
never written out.
