### PR TITLE
tls_mini: split TLS buffer placement (xmit to DRAM on Ethernet), SHIP ciphers

### DIFF
--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -249,13 +249,42 @@ void WiFiClientSecure_light::allocateBuffers(void) {
   // GitHub IDE download, weather HTTPS, sendmail). heap_caps_malloc returns NULL
   // when there is no/insufficient PSRAM, so we fall back to internal RAM and
   // non-PSRAM boards are unaffected. free() handles both heaps on ESP-IDF.
-  auto _tls_buf_alloc = [](size_t n) -> unsigned char* {
+  // Die beiden Puffer haben GEGENSAETZLICHE Anforderungen, deshalb werden sie getrennt entschieden.
+  // Vorher lagen bei aktivem EEBUS-Build BEIDE im DRAM — das behob zwar die Korruption, nahm aber
+  // dem grossen Empfangspuffer die PSRAM-Bevorzugung, um die es im Kommentar darueber geht.
+  //
+  //  * SENDEN: der Ausgabepuffer geht bei SPI-Ethernet (ETH_TYPE 4 DM9051, 8 W5500, 9 KSZ8851) per
+  //    DMA hinaus, und SPI-DMA kann nicht aus PSRAM lesen -> Speicherkorruption bei grossen
+  //    TLS-Records, an einem W5500-Geraet gemessen. Also DRAM zuerst. Kosten: hoechstens 4 KB
+  //    (groesster xmit im Baum ist MQTT-TLS mit 4096; AsyncHttpClientLight hat xmit 0).
+  //  * EMPFANGEN: bis 16384 Byte. GENAU dieser Block ist der Grund fuer die PSRAM-Bevorzugung —
+  //    im internen RAM scheitert er, sobald der fragmentiert ist (GitHub-Download, HTTPS, sendmail).
+  //    Also PSRAM zuerst, unveraendert.
+  //
+  // Bedingung ist NICHT USE_EEBUS_GUARD: der Fehler trifft jeden mit SPI-Ethernet und TLS, auch ohne
+  // EEBUS. Und nicht ETH_TYPE, weil der Typ zur Laufzeit umschaltbar ist (Kommando EthType) — ein
+  // Gate darauf waere nur die Vorgabe, keine Zusicherung. USE_ETHERNET ist die belastbare Grenze:
+  // wo kein Ethernet eincompiliert ist, bleibt alles wie bisher; wo eines ist, kostet es <= 4 KB,
+  // auch bei RMII-Chips ohne SPI. Beide Richtungen behalten ihren Rueckfall auf den anderen Heap.
+  auto _tls_buf_alloc = [](size_t n, bool dram_first) -> unsigned char* {
+    if (dram_first) {
+      unsigned char *p = (unsigned char*) malloc(n);
+      if (!p) { p = (unsigned char*) heap_caps_malloc(n, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT); }
+      return p;
+    }
     unsigned char *p = (unsigned char*) heap_caps_malloc(n, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (!p) { p = (unsigned char*) malloc(n); }
     return p;
   };
-  _iobuf_in  = std::shared_ptr<unsigned char>(_tls_buf_alloc(_iobuf_in_size),  [](unsigned char* p){ free(p); });
-  _iobuf_out = std::shared_ptr<unsigned char>(_tls_buf_alloc(_iobuf_out_size), [](unsigned char* p){ free(p); });
+#if defined(USE_ETHERNET)
+  const bool _tls_out_dram_first = true;
+#else
+  const bool _tls_out_dram_first = false;
+#endif
+  _iobuf_in  = std::shared_ptr<unsigned char>(_tls_buf_alloc(_iobuf_in_size,  false),
+                                              [](unsigned char* p){ free(p); });
+  _iobuf_out = std::shared_ptr<unsigned char>(_tls_buf_alloc(_iobuf_out_size, _tls_out_dram_first),
+                                              [](unsigned char* p){ free(p); });
 #else
   _iobuf_in = std::shared_ptr<unsigned char>(new unsigned char[_iobuf_in_size], std::default_delete<unsigned char[]>());
   _iobuf_out = std::shared_ptr<unsigned char>(new unsigned char[_iobuf_out_size], std::default_delete<unsigned char[]>());
@@ -913,6 +942,21 @@ extern "C" {
   static const uint16_t suites_RSA_ONLY[] = {
     BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
   };
+#if defined(USE_EEBUS_GUARD)
+  // Cipher-Reihenfolge fuer SHIP: ECDSA zuerst. 0xC02F (RSA) ist kein SHIP-Cipher, bleibt aber am
+  // Ende der Liste — diese Lib bedient auch HTTPS/MQTT zu RSA-Servern.
+  static const uint16_t suites_eebus[] = {
+    BR_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,   // v116: 0xC023 = SHIP-§9.1-PFLICHT-Cipher (normkonforme Gegenstellen fuehren ihn ZUERST an)
+    BR_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,   // 0xC02B (bisher, optional in SHIP)
+    BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,     // 0xC02F Fallback fuer Nicht-EEBUS-TLS (HTTPS/MQTT zu RSA-Servern)
+  };
+  // Genau die zwei von SHIP 9.1 vorgesehenen Suites. Nur aktiv nach setShipCiphers(true);
+  // alle uebrigen TLS-Verbindungen behalten die vollstaendige Liste oben.
+  static const uint16_t suites_ship_only[] = {
+    BR_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,   // 0xC023 = SHIP 9.1 Pflicht-Cipher (fuehrt)
+    BR_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,   // 0xC02B = SHIP 9.1 optional
+  };
+#endif
 
   // Default initializion for our SSL clients
   static void br_ssl_client_base_init(br_ssl_client_context *cc, bool _rsa_only) {
@@ -921,7 +965,18 @@ extern "C" {
     br_ssl_engine_add_flags(&cc->eng, BR_OPT_NO_RENEGOTIATION);
 
     br_ssl_engine_set_versions(&cc->eng, BR_TLS12, BR_TLS12);
-#if defined(ESP32) || (defined(ESP8266) && defined(USE_MQTT_TLS_ECDSA))
+#if defined(USE_EEBUS_GUARD)
+    // EEBUS-Build: die SHIP-taugliche Liste verwenden (s. suites_eebus oben).
+    // ABER _rsa_only MUSS weiter greifen: wer RSA erzwingt, tut das, um einen RSA-Fingerabdruck
+    // pruefen zu koennen. Bekaeme er zusaetzlich ECDSA-Suiten angeboten, koennte der Server ECDSA
+    // waehlen und die Fingerabdruck-Pruefung liefe ins Leere — ein stiller Sicherheitsverlust
+    // fuer einen Nutzer, der mit EEBUS gar nichts zu tun hat.
+    if (_rsa_only) {
+      br_ssl_engine_set_suites(&cc->eng, suites_RSA_ONLY, (sizeof suites_RSA_ONLY) / (sizeof suites_RSA_ONLY[0]));
+    } else {
+      br_ssl_engine_set_suites(&cc->eng, suites_eebus, (sizeof suites_eebus) / (sizeof suites_eebus[0]));
+    }
+#elif defined(ESP32) || (defined(ESP8266) && defined(USE_MQTT_TLS_ECDSA))
     if (_rsa_only) {
       br_ssl_engine_set_suites(&cc->eng, suites_RSA_ONLY, (sizeof suites_RSA_ONLY) / (sizeof suites_RSA_ONLY[0]));
     } else {
@@ -941,6 +996,12 @@ extern "C" {
     br_ssl_engine_set_gcm(&cc->eng, &br_sslrec_in_gcm_vtable, &br_sslrec_out_gcm_vtable);
     br_ssl_engine_set_aes_ctr(&cc->eng, &br_aes_small_ctr_vtable);
     br_ssl_engine_set_ghash(&cc->eng, &br_ghash_ctmul32);
+#if defined(USE_EEBUS_GUARD)
+    // CBC-Engine registrieren: SHIP 9.1 fuehrt 0xC023 als Pflicht-Cipher, 0xC02B (GCM) nur als
+    // Option. Rein additiv — GCM bleibt registriert, HTTPS/MQTT zu RSA-Servern unberuehrt.
+    br_ssl_engine_set_cbc(&cc->eng, &br_sslrec_in_cbc_vtable, &br_sslrec_out_cbc_vtable);
+    br_ssl_engine_set_aes_cbc(&cc->eng, &br_aes_small_cbcenc_vtable, &br_aes_small_cbcdec_vtable);
+#endif
 
     // we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
     br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);
@@ -979,6 +1040,13 @@ bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
     _eng = &_sc->eng; // Allocation/deallocation taken care of by the _sc shared_ptr
 
     br_ssl_client_base_init(_sc.get(), _rsa_only);
+#if defined(USE_EEBUS_GUARD)
+    // Suite-Liste NACH der Basis-Initialisierung ueberschreiben, nur fuer markierte Clients —
+    // andere TLS-Nutzer bleiben unberuehrt.
+    if (_ship_ciphers) {
+      br_ssl_engine_set_suites(_eng, suites_ship_only, (sizeof suites_ship_only) / (sizeof suites_ship_only[0]));
+    }
+#endif
     if (_alpn_names && _alpn_num > 0) {
       br_ssl_engine_set_protocol_names(_eng, _alpn_names, _alpn_num);
     }

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -142,6 +142,15 @@ class WiFiClientSecure_light : public WiFiClient {
       _domain = domain;
     }
 
+    // Nur die ZWEI von SHIP 9.1 definierten Cipher-Suites anbieten (0xC023 CBC = Pflicht,
+    // dann 0xC02B GCM = optional). Ohne diesen Schalter bleibt es bei der vollen Liste, die
+    // zusaetzlich 0xC02F (ECDHE_RSA) fuehrt — kein SHIP-Cipher, aber noetig fuer HTTPS/MQTT
+    // zu RSA-Servern. Wirkt PRO VERBINDUNG, andere Dienste bleiben unberuehrt.
+    // Vor connect() setzen.
+    void setShipCiphers(bool on) {
+      _ship_ciphers = on;
+    }
+
   private:
     uint32_t _loopTimeout=10000;
     void _clear();
@@ -161,6 +170,7 @@ class WiFiClientSecure_light : public WiFiClient {
     bool _fingerprint_any;            // accept all fingerprints
     bool _insecure;                   // force fingerprint
     bool _rsa_only;                   // restrict to RSA only key exchange (no ECDSA - enabled to force RSA fingerprints)
+    bool _ship_ciphers = false;       // nur die 2 SHIP-9.1-Suites anbieten (s. setShipCiphers)
     const uint8_t *_fingerprint1;          // fingerprint1 to be checked against
     const uint8_t *_fingerprint2;          // fingerprint2 to be checked against
     uint8_t _recv_fingerprint[20];   // fingerprint received


### PR DESCRIPTION
## Description

Schritt 2 von drei, wie besprochen. Zwei Commits, zwei Dateien, beide in `tls_mini`.

### Sendepuffer in den DRAM, Empfangspuffer bleibt im PSRAM

Die beiden Puffer haben gegensaetzliche Anforderungen, deshalb werden sie jetzt getrennt entschieden statt gemeinsam:

* **Senden -> DRAM zuerst**, PSRAM als Rueckfall. Bei SPI-Ethernet geht der Ausgabepuffer per DMA hinaus, und SPI-DMA kann nicht aus PSRAM lesen - an einem W5500 als Speicherkorruption bei grossen TLS-Records beobachtet. Kosten hoechstens 4 KB (groesster `xmit` im Baum ist MQTT-TLS mit 4096; `AsyncHttpClientLight` hat `xmit 0`).
* **Empfangen -> unveraendert PSRAM zuerst.** Genau dieser Block (bis 16384) ist der Grund, aus dem die PSRAM-Bevorzugung eingefuehrt wurde; ihn zurueck in den internen DRAM zu legen haette die Handshake-Fehler zurueckgeholt, die der Kommentar darueber beim Namen nennt.

Bedingung ist `USE_ETHERNET`, nicht `ETH_TYPE`: drei der `ETH_TYPE`-Werte sind SPI-Chips (4 DM9051, 8 W5500, 9 KSZ8851), die uebrigen sind RMII - und `EthType` ist zur Laufzeit umschaltbar, ein Compile-Gate darauf waere die Vorgabe, keine Zusicherung. Wo kein Ethernet eincompiliert ist, aendert sich nichts.

Der Preis, sehenden Auges benannt: die <= 4 KB fallen auch auf RMII-Geraeten an, die kein SPI im Datenweg haben, und auf Geraeten, die Ethernet eincompiliert haben, aber ueber WLAN laufen.

### Hinter `USE_EEBUS_GUARD`: SHIP-Cipher

Die beiden von SHIP 9.1 vorgesehenen Suiten (`0xC023` Pflicht, `0xC02B` optional), die CBC-Record-Engine und ein Schalter `setShipCiphers()`, der je Verbindung wirkt. `_rsa_only` behaelt Vorrang vor der EEBUS-Liste - wer RSA erzwingt, tut das, um einen Fingerabdruck pruefen zu koennen, und darf dabei nicht still ECDSA angeboten bekommen.

Zehn Zeilen in der `.h` sind die einzigen, die **nicht** hinter dem Define liegen: ein `bool`-Feld und ein Inline-Setter. Beide sind wirkungslos, solange `setShipCiphers()` niemand ruft, und die Liste, die der Schalter auswaehlt, existiert nur im EEBUS-Build.

### Was geprueft ist - und was nicht

Geprueft an meinem Geraet (ESP32-S3 mit W5500), mit dieser Fassung: vollstaendige EEBUS-Sitzung, Use-Case-Auskunft 5.209 B empfangen (ueber einen 2048er Puffer, also in Fragmenten, aus dem PSRAM), Discovery-Antwort 3.491 B gesendet aus dem DRAM, zwei Schreibvorgaenge a 756 B aus dem DRAM mit `errorNumber:0`, anschliessend ein vollstaendiger Zyklus bis zum regulaeren Ablauf beider Vorgaben. Kein Absturz, Heap unveraendert.

**Nicht geprueft ist der 16-KB-Empfangsfall.** `AsyncHttpClientLight` wird ausschliesslich von Berry benutzt, und Berry ist in meinem Build nicht drin. Dieser Weg bleibt von der Aenderung allerdings unberuehrt: der Empfang lag vorher im PSRAM und liegt nachher im PSRAM.

### Zur Checkliste

Bewusst leer gelassen, statt anzukreuzen, was ich nicht belegen kann:

* **ESP8266** trifft nicht zu - der geaenderte Block steht in einem `#ifndef ESP8266`-Zweig.
* **core ESP32 V.1.12.2** - geprueft ist auf dem Core, der hier laeuft, nicht auf dieser Version.
* **Ein Feature pro PR** - es sind streng genommen zwei Dinge; sie haengen zusammen (beide in `tls_mini`, beide aus demselben Befund) und waren als ein Schritt verabredet.