### PR TITLE
xdrv_126: replace a stray NUL byte so git stops treating the file as binary

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_126_eebus_guard.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_126_eebus_guard.ino
@@ -3535,7 +3535,7 @@ void EebusHarvest(const char *json, int src_ent) {
           ESp->lim_dur_s[lid]  = EebusIsoDurSecs(ESp->lim_dur[lid]);
           ESp->lim_dur_at[lid] = millis();
         } else {
-          ESp->lim_dur[lid][0] = ' ';
+          ESp->lim_dur[lid][0] = '\0';
         }
       }
       q += 10;


### PR DESCRIPTION
## Description

Nachtrag zu #104, ein Byte.

In Zeile 3538 stand zwischen den Hochkommata ein **rohes 0x00-Byte** statt der zwei Zeichen
`\` und `0`:

```diff
-          ESp->lim_dur[lid][0] = '<NUL>';
+          ESp->lim_dur[lid][0] = '\0';
```

### Es aendert kein Verhalten

Der Compiler liest das Byte als Zeichenkonstante mit dem Wert 0 — genau das, was `'\0'` bedeutet.
Die Zeile hat in dieser Form monatelang uebersetzt und laeuft so auf meinem Geraet. Es ist keine
Fehlerbehebung im Sinne der Funktion.

### Warum es trotzdem wichtig ist

**Wegen dieses einen Bytes stuft git die ganze Datei als binaer ein.** Praktische Folgen bei 6.069
Zeilen Quelltext:

- keine Diffs, kein `git blame`, keine Zusammenfuehrung
- keine Zeilenenden-Normalisierung — die Datei entgeht `core.autocrlf` vollstaendig. Speichert sie
  jemand einmal mit CRLF, geht ein Diff ueber alle 6.069 Zeilen an dich raus, ohne dass sich ein
  Zeichen Inhalt geaendert haette

Nach dem Entfernen erzeugt `git diff` fuer diese Aenderung erstmals ueberhaupt einen lesbaren Diff
(`1 file changed, 1 insertion(+), 1 deletion(-)`) und meldet von sich aus, dass es die Datei
kuenftig normalisieren wird. Beides war vorher unmoeglich.

### Wie es hineingekommen ist

Vermutlich bei einem Suchen-und-Ersetzen-Lauf ueber die Datei, bei dem `\0` als Escape-Sequenz
ausgewertet und durch das echte Byte ersetzt wurde. Aufgefallen ist es erst, als ich nach dem
Zusammenfuehren gemessen habe, warum diese eine Datei als einzige nicht auf CRLF umgestellt wurde.

### Geprueft

- genau ein NUL-Byte in der Datei, jetzt keines mehr
- Groesse 350.947 -> 350.948 Byte, also **+1**
- weiterhin 0 CR-Zeichen
- `git diff`: eine Zeile

**Nicht** neu uebersetzt oder geflasht — die Aenderung ist eine Zeichenkonstante, die vorher und
nachher denselben Wert hat.

---

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).