### PR TITLE
xdrv_126: clear the peer heartbeat state on disconnect

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_126_eebus_guard.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_126_eebus_guard.ino
@@ -4470,6 +4470,13 @@ void EebusDisconnectNow(void) {
   }
   ESp->sme = SME_OFF;
   ESp->state = SHIP_IDLE;
+   // Herzschlag-Ueberwachung stilllegen. Ohne Verbindung kommt kein Herzschlag mehr, und ein
+   // stehengebliebener Zeitstempel laesst die Anzeige weiter altern, als wuerde noch ueberwacht:
+   // gemessen zaehlte "PeerHerzschlagS" nach dem Trennen ungebremst von 43 auf 115 hoch. Ein
+   // Fehlalarm kann daraus zwar nicht entstehen (ohne Datenphase wird gar nicht geprueft), aber
+   // es waere genau die Sorte Anzeige, gegen die diese Ueberwachung gebaut wurde.
+   // ⚠️ Zaehler und Zeitpunkt der Vorfaelle bleiben ABSICHTLICH stehen — sie sind die Vorfallsliste.
+  ESp->peer_hb_at = 0; ESp->peer_hb_ctr = 0; ESp->peer_hb_tmo_s = 0; ESp->peer_hb_lost = false;
   if (ESp->via_srv) {
     EebusSrvFree();   // Server-Verbindung komplett schliessen (Socket+Unlink)
   } else if (ESp->client) {


### PR DESCRIPTION
## Description:

Follow-up to #106, one small correction to my own work there.

Disconnecting left the peer heartbeat timestamp in place, so `EEBusStatus` kept reporting an ever growing `PeerHerzschlagS` for a slot that was no longer connected — measured climbing from 43 to 115 seconds while the slot sat at `idle/off`. No false alarm can come from it (the supervision only runs once the data phase is reached), but it is exactly the kind of reading this supervision was built against: one that claims something which is no longer true.

`EebusDisconnectNow` now clears arrival time, counter, promised timeout and the lost flag. **The incident counter and the timestamp of the last loss stay untouched on purpose** — they are the record of what happened, not live state.

**Tested on the device:** after `EEBusDisconnect` the heartbeat fields disappear from `EEBusStatus` and stay gone (checked over 45 s); after reconnecting they reappear and the age sawtooths at 60 s against the 240 s deadline as before. Reconnect and registration of both directions unaffected.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

ESP8266 does not apply (the driver is ESP32 only), and the ESP32 core in the template is not the one this was built and tested with (3.3.8 / platform 2026.05.50).
