### PR TITLE
xdrv_126: size the reconnect retry table to the number of gaps

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_126_eebus_guard.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_126_eebus_guard.ino
@@ -515,7 +515,12 @@ struct {
 
    // Abstaende zwischen den Versuchen: wachsend, NICHT die starren 8 s des Keep-Alive.
    // Zu dichte Wiederholungen sind genau der Weg in "cmi resp n=-1".
-const uint16_t kEebusAcRetryS[EEBUS_AC_MAX_TRY] PROGMEM = { 30, 60, 120, 300 };
+   // ⚠️ Es sind EINS WENIGER als Versuche: bei vier Versuchen gibt es drei Zwischenraeume.
+   // Frueher stand hier ein vierter Wert (300 s), der NIE gelesen wurde — der Zaehler laeuft
+   // 1, 2, 3, und beim vierten Versuch wird aufgegeben, bevor indiziert wird. Kein Ueberlauf,
+   // aber Text und Code widersprachen sich. Bewusst die Tabelle gekuerzt statt die Zahl der
+   // Versuche erhoeht: so aendert sich am Verhalten nichts, nur die Beschreibung stimmt wieder.
+const uint16_t kEebusAcRetryS[EEBUS_AC_MAX_TRY - 1] PROGMEM = { 30, 60, 120 };
 
 enum EebusAcState : uint8_t { AC_IDLE, AC_WAIT, AC_SCAN, AC_DONE };
 


### PR DESCRIPTION
`kEebusAcRetryS` held four values, but only three were ever read: the counter
runs 1, 2, 3, and the fourth attempt gives up before the table is indexed.
No overflow — but the comment and the code contradicted each other.

The table is shortened to `EEBUS_AC_MAX_TRY - 1` instead of raising the number
of attempts, so **behaviour is unchanged**; only the description matches the
code again.

Found and reported by @gemu2015.

## Description:

Tested on real hardware: ESP32-S3 with Ethernet, Tasmota 15.5.0.1, core 3.3.8,
IDF 5.5.4.260407. The self-reconnect after a restart ran twice today and
connected on attempt 1 of 4 each time, followed by the usual LPC and LPP
registration (`errorNumber: 0`, read-back confirmed).

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_The two core boxes are left unchecked on purpose: this driver is ESP32-only
(`#ifndef ESP8266`), and it was verified on core 3.3.8 rather than the versions
named above._